### PR TITLE
add Shadow Beacon contract

### DIFF
--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -50,7 +50,6 @@ contract ShadowBeacon is ERC721, Ownable {
     uint256 id
   ) public override {
     if (msg.sender != allowedSigner) revert OnlyAuthorizedSigner();
-    require(msg.sender == allowedSigner, "ONLY_ALLOWED_SIGNER");
     require(from == ownerOf[id], "WRONG_FROM");
 
     if (ownerOf[id] == address(0)) {

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -52,15 +52,12 @@ contract ShadowBeacon is ERC721, Ownable {
     if (msg.sender != allowedSigner) revert OnlyAuthorizedSigner();
     require(from == ownerOf[id], "WRONG_FROM");
 
-    if (ownerOf[id] == address(0)) {
-      _mint(to, id);
-      return;
-    }
-
     // Underflow of the sender's balance is impossible because we check for
     // ownership above and the recipient's balance can't realistically overflow.
     unchecked {
-      balanceOf[from]--;
+      if (from != address(0)) {
+        balanceOf[from]--;
+      }
       balanceOf[to]++;
     }
 

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -25,6 +25,9 @@ contract ShadowBeacon is ERC721, Ownable {
   string public baseURI;
   address public allowedSigner;
 
+  error TokenIsNonTransferrable();
+  error OnlyAuthorizedSigner();
+
   constructor(address _allowedSigner) ERC721("Shadow Beacon", "SHDB") {
     allowedSigner = _allowedSigner;
   }
@@ -46,6 +49,7 @@ contract ShadowBeacon is ERC721, Ownable {
     address to,
     uint256 id
   ) public override {
+    if (msg.sender != allowedSigner) revert OnlyAuthorizedSigner();
     require(msg.sender == allowedSigner, "ONLY_ALLOWED_SIGNER");
     require(from == ownerOf[id], "WRONG_FROM");
 
@@ -79,11 +83,11 @@ contract ShadowBeacon is ERC721, Ownable {
   // Disabled functions //
 
   function approve(address, uint256) public pure override {
-    revert("NON_TRANSFERABLE");
+    revert TokenIsNonTransferrable();
   }
 
   function setApprovalForAll(address, bool) public pure override {
-    revert("NON_TRANSFERABLE");
+    revert TokenIsNonTransferrable();
   }
 
   function safeTransferFrom(
@@ -91,7 +95,7 @@ contract ShadowBeacon is ERC721, Ownable {
     address,
     uint256
   ) public pure override {
-    revert("NON_TRANSFERABLE");
+    revert TokenIsNonTransferrable();
   }
 
   function safeTransferFrom(
@@ -100,6 +104,6 @@ contract ShadowBeacon is ERC721, Ownable {
     uint256,
     bytes memory
   ) public pure override {
-    revert("NON_TRANSFERABLE");
+    revert TokenIsNonTransferrable();
   }
 }

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -28,9 +28,7 @@ contract ShadowBeacon is ERC721, Ownable {
     error TokenIsNonTransferrable();
     error OnlyAuthorizedSigner();
 
-    constructor(address _allowedSigner, string memory _baseURI)
-        ERC721("SHADOW Beacon", "SHDB")
-    {
+    constructor(address _allowedSigner, string memory _baseURI) ERC721("SHADOW Beacon", "SHDB") {
         allowedSigner = _allowedSigner;
         baseURI = _baseURI;
     }
@@ -70,12 +68,7 @@ contract ShadowBeacon is ERC721, Ownable {
 
     // View functions //
 
-    function tokenURI(uint256 tokenID)
-        public
-        view
-        override
-        returns (string memory)
-    {
+    function tokenURI(uint256 tokenID) public view override returns (string memory) {
         return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
     }
 

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -29,7 +29,7 @@ contract ShadowBeacon is ERC721, Ownable {
     error OnlyAuthorizedSigner();
 
     constructor(address _allowedSigner, string memory _baseURI)
-        ERC721("Shadow Beacon", "SHDB")
+        ERC721("SHADOW Beacon", "SHDB")
     {
         allowedSigner = _allowedSigner;
         baseURI = _baseURI;

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -69,7 +69,7 @@ contract ShadowBeacon is ERC721, Ownable {
     // View functions //
 
     function tokenURI(uint256 tokenID) public view override returns (string memory) {
-        return string(abi.encodePacked(baseURI, Strings.toString(tokenID), ".svg"));
+        return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
     }
 
     // Disabled functions //

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -28,8 +28,11 @@ contract ShadowBeacon is ERC721, Ownable {
   error TokenIsNonTransferrable();
   error OnlyAuthorizedSigner();
 
-  constructor(address _allowedSigner) ERC721("Shadow Beacon", "SHDB") {
+  constructor(address _allowedSigner, string memory _baseURI)
+    ERC721("Shadow Beacon", "SHDB")
+  {
     allowedSigner = _allowedSigner;
+    baseURI = _baseURI;
   }
 
   // Admin functions //

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -22,87 +22,87 @@ import "openzeppelin/access/Ownable.sol";
 pragma solidity >=0.8.10;
 
 contract ShadowBeacon is ERC721, Ownable {
-  string public baseURI;
-  address public allowedSigner;
+    string public baseURI;
+    address public allowedSigner;
 
-  error TokenIsNonTransferrable();
-  error OnlyAuthorizedSigner();
+    error TokenIsNonTransferrable();
+    error OnlyAuthorizedSigner();
 
-  constructor(address _allowedSigner, string memory _baseURI)
-    ERC721("Shadow Beacon", "SHDB")
-  {
-    allowedSigner = _allowedSigner;
-    baseURI = _baseURI;
-  }
-
-  // Admin functions //
-
-  function setBaseURI(string memory _baseURI) public onlyOwner {
-    baseURI = _baseURI;
-  }
-
-  function setAllowedSigner(address _allowedSigner) public onlyOwner {
-    allowedSigner = _allowedSigner;
-  }
-
-  // Signer functions //
-
-  function transferFrom(
-    address from,
-    address to,
-    uint256 id
-  ) public override {
-    if (msg.sender != allowedSigner) revert OnlyAuthorizedSigner();
-    require(from == ownerOf[id], "WRONG_FROM");
-
-    // Underflow of the sender's balance is impossible because we check for
-    // ownership above and the recipient's balance can't realistically overflow.
-    unchecked {
-      if (from != address(0)) {
-        balanceOf[from]--;
-      }
-      balanceOf[to]++;
+    constructor(address _allowedSigner, string memory _baseURI)
+        ERC721("Shadow Beacon", "SHDB")
+    {
+        allowedSigner = _allowedSigner;
+        baseURI = _baseURI;
     }
 
-    ownerOf[id] = to;
-    emit Transfer(from, to, id);
-  }
+    // Admin functions //
 
-  // View functions //
+    function setBaseURI(string memory _baseURI) public onlyOwner {
+        baseURI = _baseURI;
+    }
 
-  function tokenURI(uint256 tokenID)
-    public
-    view
-    override
-    returns (string memory)
-  {
-    return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
-  }
+    function setAllowedSigner(address _allowedSigner) public onlyOwner {
+        allowedSigner = _allowedSigner;
+    }
 
-  // Disabled functions //
+    // Signer functions //
 
-  function approve(address, uint256) public pure override {
-    revert TokenIsNonTransferrable();
-  }
+    function transferFrom(
+        address from,
+        address to,
+        uint256 id
+    ) public override {
+        if (msg.sender != allowedSigner) revert OnlyAuthorizedSigner();
+        require(from == ownerOf[id], "WRONG_FROM");
 
-  function setApprovalForAll(address, bool) public pure override {
-    revert TokenIsNonTransferrable();
-  }
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        unchecked {
+            if (from != address(0)) {
+                balanceOf[from]--;
+            }
+            balanceOf[to]++;
+        }
 
-  function safeTransferFrom(
-    address,
-    address,
-    uint256
-  ) public pure override {
-    revert TokenIsNonTransferrable();
-  }
+        ownerOf[id] = to;
+        emit Transfer(from, to, id);
+    }
 
-  function safeTransferFrom(
-    address,
-    address,
-    uint256,
-    bytes memory
-  ) public pure override {
-    revert TokenIsNonTransferrable();
-  }
+    // View functions //
+
+    function tokenURI(uint256 tokenID)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
+    }
+
+    // Disabled functions //
+
+    function approve(address, uint256) public pure override {
+        revert TokenIsNonTransferrable();
+    }
+
+    function setApprovalForAll(address, bool) public pure override {
+        revert TokenIsNonTransferrable();
+    }
+
+    function safeTransferFrom(
+        address,
+        address,
+        uint256
+    ) public pure override {
+        revert TokenIsNonTransferrable();
+    }
+
+    function safeTransferFrom(
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) public pure override {
+        revert TokenIsNonTransferrable();
+    }
 }

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -1,0 +1,105 @@
+//    .^7??????????????????????????????????????????????????????????????????7!:       .~7????????????????????????????????:
+//     :#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@Y   ^#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@5
+//    ^@@@@@@#BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB&@@@@@B ~@@@@@@#BBBBBBBBBBBBBBBBBBBBBBBBBBBBB#7
+//    Y@@@@@#                                                                ~@@@@@@ P@@@@@G
+//    .&@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@&G~ ~@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@Y :@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@&P~
+//      J&@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@#.!B@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@B~   .Y&@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@B
+//         ...........................B@@@@@5  .7#@@@@@@@#?^....................          ..........................:#@@@@@J
+//    ^5YYYJJJJJJJJJJJJJJJJJJJJJJJJJJY&@@@@@?     .J&@@@@@@&5JJJJJJJJJJJJJJJJJJJYYYYYYYYYYJJJJJJJJJJJJJJJJJJJJJJJJJJY@@@@@@!
+//    5@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@?         :5&@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@7
+//    !GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGPY~              ^JPGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGPJ^
+
+//  _______________________________________________________ Tomb Series  ___________________________________________________
+
+// Shadow Beacon
+// Contract by Luke Miles (@worm_emoji)
+// SPDX-License-Identifier: MIT
+
+import "solmate/tokens/ERC721.sol";
+import "openzeppelin/utils/Strings.sol";
+import "openzeppelin/access/Ownable.sol";
+
+pragma solidity >=0.8.10;
+
+contract ShadowBeacon is ERC721, Ownable {
+  string public baseURI;
+  address public allowedSigner;
+
+  constructor(address _allowedSigner) ERC721("Shadow Beacon", "SHDB") {
+    allowedSigner = _allowedSigner;
+  }
+
+  // Admin functions //
+
+  function setBaseURI(string memory _baseURI) public onlyOwner {
+    baseURI = _baseURI;
+  }
+
+  function setAllowedSigner(address _allowedSigner) public onlyOwner {
+    allowedSigner = _allowedSigner;
+  }
+
+  // Signer functions //
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 id
+  ) public override {
+    require(msg.sender == allowedSigner, "ONLY_ALLOWED_SIGNER");
+    require(from == ownerOf[id], "WRONG_FROM");
+
+    if (ownerOf[id] == address(0)) {
+      _mint(to, id);
+      return;
+    }
+
+    // Underflow of the sender's balance is impossible because we check for
+    // ownership above and the recipient's balance can't realistically overflow.
+    unchecked {
+      balanceOf[from]--;
+      balanceOf[to]++;
+    }
+
+    ownerOf[id] = to;
+    emit Transfer(from, to, id);
+  }
+
+  // View functions //
+
+  function tokenURI(uint256 tokenID)
+    public
+    view
+    override
+    returns (string memory)
+  {
+    return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
+  }
+
+  // Disabled functions //
+
+  function approve(address, uint256) public pure override {
+    revert("NON_TRANSFERABLE");
+  }
+
+  function setApprovalForAll(address, bool) public pure override {
+    revert("NON_TRANSFERABLE");
+  }
+
+  function safeTransferFrom(
+    address,
+    address,
+    uint256
+  ) public pure override {
+    revert("NON_TRANSFERABLE");
+  }
+
+  function safeTransferFrom(
+    address,
+    address,
+    uint256,
+    bytes memory
+  ) public pure override {
+    revert("NON_TRANSFERABLE");
+  }
+}

--- a/src/ShadowBeacon.sol
+++ b/src/ShadowBeacon.sol
@@ -69,7 +69,7 @@ contract ShadowBeacon is ERC721, Ownable {
     // View functions //
 
     function tokenURI(uint256 tokenID) public view override returns (string memory) {
-        return string(abi.encodePacked(baseURI, Strings.toString(tokenID)));
+        return string(abi.encodePacked(baseURI, Strings.toString(tokenID), ".svg"));
     }
 
     // Disabled functions //

--- a/src/ShadowBeaconDummy.sol
+++ b/src/ShadowBeaconDummy.sol
@@ -1,0 +1,24 @@
+// File: contracts/Shadow.sol
+
+pragma solidity ^0.8.0;
+
+import "solmate/tokens/ERC721.sol";
+import "openzeppelin/access/Ownable.sol";
+
+// used for testing shadow beacon on goerli
+contract ShadowBeaconDummy is ERC721, Ownable {
+    constructor() public ERC721("House SHADOW TEST", "SHD") {
+        for (uint256 i = 1; i <= 36; i++) {
+            _mint(msg.sender, i);
+        }
+    }
+
+    function tokenURI(uint256 tokenID)
+        public
+        pure
+        override
+        returns (string memory)
+    {
+        return "";
+    }
+}

--- a/src/ShadowBeaconDummy.sol
+++ b/src/ShadowBeaconDummy.sol
@@ -13,12 +13,7 @@ contract ShadowBeaconDummy is ERC721, Ownable {
         }
     }
 
-    function tokenURI(uint256 tokenID)
-        public
-        pure
-        override
-        returns (string memory)
-    {
+    function tokenURI(uint256 tokenID) public pure override returns (string memory) {
         return "";
     }
 }

--- a/src/scripts/SyncShadowBeacon.sol
+++ b/src/scripts/SyncShadowBeacon.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "forge-std/Script.sol";
+import "../ShadowBeacon.sol";
+import "../ShadowNFT.sol";
+
+contract SyncShadowBeacon is Script {
+    address public constant SHADOW_BEACON_GOERLI = 0x975cED3A79e4FCc48B6E309A286DC49A4Bc44042;
+    address public constant CANONICAL_SHADOW_MUMBAI = 0xA6C299948F095C2dCD7d0e6a3b7B2C7AaD0e28b4;
+    string public goerliRPCUrl = vm.envString("GOERLI_RPC_URL");
+    string public mumbaiRPCUrl = vm.envString("MUMBAI_RPC_URL");
+
+    address public constant SHADOW_BEACON_MAINNET = 0x819c573D8d8BE12095606Cb846E81913F2cDd140;
+    address public constant CANONICAL_SHADOW_POLYGON = 0xE877CDACBB7827d4232Cde5f8de58371F144a0A4;
+    string public mainnetRPCUrl = vm.envString("MAINNET_RPC_URL");
+    string public polygonRPCUrl = vm.envString("POLYGON_RPC_URL");
+
+    function run() public {
+        if (block.chainid == 1) {
+            run(SHADOW_BEACON_MAINNET, CANONICAL_SHADOW_POLYGON, mainnetRPCUrl, polygonRPCUrl);
+        } else {
+            run(SHADOW_BEACON_GOERLI, CANONICAL_SHADOW_MUMBAI, goerliRPCUrl, mumbaiRPCUrl);
+        }
+    }
+
+    function run(
+        address beaconAddress,
+        address canonicalShadowAddress,
+        string memory beaconRpcUrl,
+        string memory canonicalShadowRpcUrl
+    ) public {
+        uint256 shadowRPC = vm.createFork(canonicalShadowRpcUrl);
+        uint256 beaconRPC = vm.createFork(beaconRpcUrl);
+
+        address[] memory canonicalOwners = new address[](36);
+
+        vm.selectFork(shadowRPC);
+        Shadow shadowNFT = Shadow(canonicalShadowAddress);
+
+        for (uint256 i = 0; i < 36; i++) {
+            canonicalOwners[i] = shadowNFT.ownerOf(i + 1);
+        }
+
+        vm.selectFork(beaconRPC);
+        ShadowBeacon beacon = ShadowBeacon(beaconAddress);
+
+        uint256 deployerPrivateKey = vm.envUint("SHADOW_BEACON_RELAY_PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        for (uint256 i = 0; i < 36; i++) {
+            address owner = beacon.ownerOf(i + 1);
+            if (owner != canonicalOwners[i]) {
+                beacon.transferFrom(owner, canonicalOwners[i], i + 1);
+            }
+        }
+        vm.stopBroadcast();
+    }
+}

--- a/src/test/ShadowBeacon.t.sol
+++ b/src/test/ShadowBeacon.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.0;
 import { ShadowBeacon } from "../ShadowBeacon.sol";
 import { DSTest } from "ds-test/test.sol";
 import { Utilities } from "./utils/Utilities.sol";
-import { console } from "./utils/Console.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 contract ShadowBeaconTest is DSTest {
@@ -13,7 +12,7 @@ contract ShadowBeaconTest is DSTest {
   address signer = address(1234);
 
   function setUp() public {
-    beacon = new ShadowBeacon(signer);
+    beacon = new ShadowBeacon(signer, "");
     vm.prank(signer, signer);
     beacon.transferFrom(address(0), address(1), 1);
   }

--- a/src/test/ShadowBeacon.t.sol
+++ b/src/test/ShadowBeacon.t.sol
@@ -40,7 +40,7 @@ contract ShadowBeaconTest is DSTest {
 
   function testSignerTransferFromMint() public {
     vm.prank(signer, signer);
-    beacon.transferFrom(address(0), address(60), 60);
-    assertEq(beacon.ownerOf(60), address(60));
+    beacon.transferFrom(address(0), address(62), 60);
+    assertEq(beacon.ownerOf(60), address(62));
   }
 }

--- a/src/test/ShadowBeacon.t.sol
+++ b/src/test/ShadowBeacon.t.sol
@@ -1,46 +1,46 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import { ShadowBeacon } from "../ShadowBeacon.sol";
-import { DSTest } from "ds-test/test.sol";
-import { Utilities } from "./utils/Utilities.sol";
-import { Vm } from "forge-std/Vm.sol";
+import {ShadowBeacon} from "../ShadowBeacon.sol";
+import {DSTest} from "ds-test/test.sol";
+import {Utilities} from "./utils/Utilities.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract ShadowBeaconTest is DSTest {
-  ShadowBeacon internal beacon;
-  Vm internal immutable vm = Vm(HEVM_ADDRESS);
-  address signer = address(1234);
+    ShadowBeacon internal beacon;
+    Vm internal immutable vm = Vm(HEVM_ADDRESS);
+    address signer = address(1234);
 
-  function setUp() public {
-    beacon = new ShadowBeacon(signer, "");
-    vm.prank(signer, signer);
-    beacon.transferFrom(address(0), address(1), 1);
-  }
+    function setUp() public {
+        beacon = new ShadowBeacon(signer, "");
+        vm.prank(signer, signer);
+        beacon.transferFrom(address(0), address(1), 1);
+    }
 
-  function testFailSetApprovalForAll() public {
-    vm.prank(address(1), address(1));
-    beacon.setApprovalForAll(address(2421), true);
-  }
+    function testFailSetApprovalForAll() public {
+        vm.prank(address(1), address(1));
+        beacon.setApprovalForAll(address(2421), true);
+    }
 
-  function testFailTransferFrom() public {
-    vm.prank(address(1), address(1));
-    beacon.transferFrom(address(1), address(2), 1);
-  }
+    function testFailTransferFrom() public {
+        vm.prank(address(1), address(1));
+        beacon.transferFrom(address(1), address(2), 1);
+    }
 
-  function testFailSafeTransferFrom() public {
-    vm.prank(address(1), address(1));
-    beacon.safeTransferFrom(address(1), address(2), 1);
-  }
+    function testFailSafeTransferFrom() public {
+        vm.prank(address(1), address(1));
+        beacon.safeTransferFrom(address(1), address(2), 1);
+    }
 
-  function testSignerTransferFrom() public {
-    vm.prank(signer, signer);
-    beacon.transferFrom(address(1), address(2), 1);
-    assertEq(beacon.ownerOf(1), address(2));
-  }
+    function testSignerTransferFrom() public {
+        vm.prank(signer, signer);
+        beacon.transferFrom(address(1), address(2), 1);
+        assertEq(beacon.ownerOf(1), address(2));
+    }
 
-  function testSignerTransferFromMint() public {
-    vm.prank(signer, signer);
-    beacon.transferFrom(address(0), address(62), 60);
-    assertEq(beacon.ownerOf(60), address(62));
-  }
+    function testSignerTransferFromMint() public {
+        vm.prank(signer, signer);
+        beacon.transferFrom(address(0), address(62), 60);
+        assertEq(beacon.ownerOf(60), address(62));
+    }
 }

--- a/src/test/ShadowBeacon.t.sol
+++ b/src/test/ShadowBeacon.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { ShadowBeacon } from "../ShadowBeacon.sol";
+import { DSTest } from "ds-test/test.sol";
+import { Utilities } from "./utils/Utilities.sol";
+import { console } from "./utils/Console.sol";
+import { Vm } from "forge-std/Vm.sol";
+
+contract ShadowBeaconTest is DSTest {
+  ShadowBeacon internal beacon;
+  Vm internal immutable vm = Vm(HEVM_ADDRESS);
+  address signer = address(1234);
+
+  function setUp() public {
+    beacon = new ShadowBeacon(signer);
+    vm.prank(signer, signer);
+    beacon.transferFrom(address(0), address(1), 1);
+  }
+
+  function testFailSetApprovalForAll() public {
+    vm.prank(address(1), address(1));
+    beacon.setApprovalForAll(address(2421), true);
+  }
+
+  function testFailTransferFrom() public {
+    vm.prank(address(1), address(1));
+    beacon.transferFrom(address(1), address(2), 1);
+  }
+
+  function testFailSafeTransferFrom() public {
+    vm.prank(address(1), address(1));
+    beacon.safeTransferFrom(address(1), address(2), 1);
+  }
+
+  function testSignerTransferFrom() public {
+    vm.prank(signer, signer);
+    beacon.transferFrom(address(1), address(2), 1);
+    assertEq(beacon.ownerOf(1), address(2));
+  }
+
+  function testSignerTransferFromMint() public {
+    vm.prank(signer, signer);
+    beacon.transferFrom(address(0), address(60), 60);
+    assertEq(beacon.ownerOf(60), address(60));
+  }
+}


### PR DESCRIPTION
creates the Shadow Beacon contract, a non transferrable NFT that will be used by a offchain signer to keep a mainnet mapping of polygon shadow ownership